### PR TITLE
Set the environment to inactive before deleting

### DIFF
--- a/review-cleanup/action.yml
+++ b/review-cleanup/action.yml
@@ -16,6 +16,14 @@ runs:
     - name: Deactivate Review Environment
       uses: bobheadxi/deployments@v1.1.0
       with:
+        step: deactivate-env
+        token: ${{ inputs.repo_token }}
+        env: review-${{ github.event.number }}
+        desc: Environment Pruned
+
+    - name: Delete Review Environment
+      uses: bobheadxi/deployments@v1.1.0
+      with:
         step: delete-env
         token: ${{ inputs.repo_token }}
         env: review-${{ github.event.number }}


### PR DESCRIPTION
https://docs.github.com/en/rest/reference/deployments#delete-a-deployment

states that if there are multiple environments,
only inactive ones can be deleted.