### PR TITLE
Only setup QEMU on linux instances

### DIFF
--- a/python-setup/action.yml
+++ b/python-setup/action.yml
@@ -21,6 +21,7 @@ runs:
         fetch-depth: ${{ inputs.fetch_depth }}
 
     - name: Set up QEMU
+      if: runner.os == "Linux"
       uses: docker/setup-qemu-action@v1
 
     - name: use Node.js


### PR DESCRIPTION
This prevents failures on Mac/Win binary builds for the client app.