### PR TITLE
Drop unused db_port elements

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -2,11 +2,6 @@ name: production-deploy
 on:
   workflow_call:
     inputs:
-      db_port:
-        description: "Docker Postgres port"
-        type: number
-        required: false
-        default: 5432
       update_iam:
         description: "Update IAM Permissions"
         type: boolean
@@ -22,7 +17,6 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
   DOCKER_BUILDKIT: 1
-  DB_PORT: ${{ inputs.db_port }}
 jobs:
   deploy-production:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -2,11 +2,6 @@ name: pull-requests
 on:
   workflow_call:
     inputs:
-      db_port:
-        description: "Docker Postgres port"
-        type: number
-        required: false
-        default: 5432
       update_iam:
         description: "Update IAM Permissions"
         type: boolean
@@ -24,7 +19,6 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
   DOCKER_BUILDKIT: 1
-  DB_PORT: ${{ inputs.db_port }}
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -4,6 +4,10 @@ on:
     types: [review_requested]
   workflow_call:
     secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
       SLACK_WEBHOOK_URL:
         required: true
 env:
@@ -22,7 +26,7 @@ jobs:
 
       - name: Get Review Requested Slack Block - Team Reviewer
         if: ${{ github.event.requested_team }}
-        run: ./run pipeline review-requested-slack-blocks --pr_title "${{ github.event.pull_request.title }}" --pr_url "${{ github.event.pull_request.html_url }}" --requestor "${{ github.event.sender.login }}" --reviewer "${{ github.event.requested_team }}" >> $GITHUB_ENV
+        run: ./run pipeline review-requested-slack-blocks --pr_title "${{ github.event.pull_request.title }}" --pr_url "${{ github.event.pull_request.html_url }}" --requestor "${{ github.event.sender.login }}" --reviewer "${{ github.event.requested_team.name }}" >> $GITHUB_ENV
 
       - name: Post to Slack - Review Requested
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,12 +1,6 @@
 name: staging-deploy
 on:
   workflow_call:
-    inputs:
-      db_port:
-        description: "Docker Postgres port"
-        type: number
-        required: false
-        default: 5432
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -19,7 +13,6 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
   DOCKER_BUILDKIT: 1
-  DB_PORT: ${{ inputs.db_port }}
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With the changes to move `DB_PORT` to `pyproject.toml`and `docker-compose.yml`, we no longer need the DB port in the workflows.