### PR TITLE
Ensure no dependent workflows are in progress before starting the tests

### DIFF
--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: unitasglobal/nio-shared-actions/python-setup@main
 
+      - name: Ensure No Dependent Workflows In Progress
+        shell: bash
+        run: ./run pipeline check-dependent-workflows
+
       - name: Execute Tests
         run: ./run test ci
 

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -9,6 +9,10 @@ runs:
   steps:
     - uses: unitasglobal/nio-shared-actions/python-setup@main
 
+    - name: Ensure No Dependent Workflows In Progress
+      shell: bash
+      run: ./run pipeline check-dependent-workflows
+
     - name: Execute Tests
       shell: bash
       run: ./run test ci


### PR DESCRIPTION
This has bit us before with SDNO tests being run while NIS API is being deployed.