### PR TITLE
test "calling" api via `python` for 'better' control

### DIFF
--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -12,7 +12,6 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
-  PR_TITLE: ${{ github.event.pull_request.title }}
 jobs:
   review-requested:
     runs-on: ubuntu-latest
@@ -31,6 +30,7 @@ jobs:
         uses: jannekem/run-python-script-action@v1
         with:
           script: |
+            import json
             import os
             import urllib.request
 
@@ -42,10 +42,17 @@ jobs:
               reviewer_name = "${{ github.event.requested_team.name }}"
 
             repo = "${{ github.repository }}".split("/")[0]
-            # Get title from env and escape single-quotes
-            pr_title = os.environ["PR_TITLE"].replace("'", "\'")
 
-            request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo, headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
+            request = urllib.request.Request(
+              "${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo,
+              headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"},
+              method="POST"
+            )
 
-            data_string = "--pr_title '" + pr_title + "' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + reviewer_name
-            urllib.request.urlopen(request, data=data_string.encode("utf-8"))
+            data = {
+              "pr_url": "${{ github.event.pull_request.html_url }}",
+              "requestor": "${{ github.event.sender.login }}",
+              "reviewer": reviewer_name
+            }
+            request_data = json.dumps(data).encode("utf-8")
+            urllib.request.urlopen(request, data=request_data)

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -42,7 +42,9 @@ jobs:
             if requested_team:
               reviewer_name = "${{ github.event.requested_team.name }}"
 
-            request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}", headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
+            repo = "${{ github.repository }}".split("/")[0]
+
+            request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo, headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
 
             data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + requested_reviewer
             urllib.request.urlopen(request, data=data_string.encode("utf-8"))

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -34,12 +34,11 @@ jobs:
           script: |
             import urllib.request
 
-            reviewer_name = "the_boogeyman"
             requested_reviewer = "${{ github.event.requested_reviewer }}"
+            requested_team = "${{ github.event.requested_team }}"
             if requested_reviewer:
               reviewer_name = "${{ github.event.requested_reviewer.login }}"
-            requested_team = "${{ github.event.requested_team }}"
-            if requested_team:
+            elif requested_team:
               reviewer_name = "${{ github.event.requested_team.name }}"
 
             repo = "${{ github.repository }}".split("/")[0]

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -35,7 +35,7 @@ jobs:
             import urllib.request
 
             reviewer_name = "the_boogeyman"
-            requested_reviewer = "${{ github.event.reviewer_requested }}"
+            requested_reviewer = "${{ github.event.requested_reviewer }}"
             if requested_reviewer:
               reviewer_name = "${{ github.event.requested_reviewer.login }}"
             requested_team = "${{ github.event.requested_team }}"

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -53,7 +53,7 @@ jobs:
               "${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo,
               headers={
                 "X-Api-Token": "${{ steps.endpoint-details.outputs.token }}",
-                "Content-Type"; "application/json"
+                "Content-Type": "application/json"
               },
               method="POST",
               data=request_data

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -14,6 +14,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
+  PR_TITLE: ${{ github.event.pull_request.title }}
 jobs:
   review-requested:
     runs-on: ubuntu-latest
@@ -32,6 +33,7 @@ jobs:
         uses: jannekem/run-python-script-action@v1
         with:
           script: |
+            import os
             import urllib.request
 
             requested_reviewer = "${{ github.event.requested_reviewer }}"
@@ -42,8 +44,10 @@ jobs:
               reviewer_name = "${{ github.event.requested_team.name }}"
 
             repo = "${{ github.repository }}".split("/")[0]
+            # Get title from env and escape single-quotes
+            pr_title = os.environ["PR_TITLE"].replace("'", "\'")
 
             request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo, headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
 
-            data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + reviewer_name
+            data_string = "--pr_title '" + pr_title + "' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + reviewer_name
             urllib.request.urlopen(request, data=data_string.encode("utf-8"))

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -42,7 +42,7 @@ jobs:
             if requested_team:
               reviewer_name = "${{ github.event.requested_team.name }}"
 
-            request = urllib.request.Request("${{ steps.endpoint-details.url }}", headers={"X-Api-Token": "${{ steps.endpoint-details.token }}"}, method="POST")
+            request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}", headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
 
             data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + requested_reviewer
             urllib.request.urlopen(request, data=data_string)

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -2,6 +2,8 @@ name: review-requested
 on:
   pull_request:
     types: [review_requested]
+  workflow_dispatch:
+
   workflow_call:
     secrets:
       AWS_ACCESS_KEY_ID:
@@ -16,22 +18,30 @@ jobs:
   review-requested:
     runs-on: ubuntu-latest
     steps:
-      - name: Post Review Requested to Slack
+      - name: Get URL and Token
+        id: endpoint-details
         run: |
           URL=$(aws ssm get-parameter --name ' /nio/development/slack_notifications/url' --with-decryption | jq -r '.Parameter.Value')
           TOKEN=$(aws ssm get-parameter --name ' /nio/development/slack_notifications/token' --with-decryption | jq -r '.Parameter.Value')
+          echo "::set-output name=url::$URL"
+          echo "::set-output name=token::$TOKEN"
 
-          IFS=/ read -r owner repo <<< "${{ github.repository }}"
+      - uses: actions/setup-python@v2
 
-          FULL_URL="${URL}notify?event_type=review_requested&repo=${repo}"
+      - name: jannekem/run-python-script-action@v1
+        with:
+          script: |
+            import urllib.request
 
-          if [ -n "${{ github.event.requested_reviewer }}" ]; then
-            data_string="--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer ${{ github.event.requested_reviewer.login }}"
-          elif [ -n "${{ github.event.requested_team }}" ]; then
-            data_string="--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer ${{ github.event.requested_team.name }}"
-          else
-            echo "No Reviewer Found!"
-            exit 1
-          fi
+            reviewer_name = "the_boogeyman"
+            requested_reviewer = "${{ github.event.reviewer_requested }}"
+            if requested_reviewer:
+              reviewer_name = "${{ github.event.requested_reviewer.login }}"
+            requested_team = "${{ github.event.requested_team }}"
+            if requested_team:
+              reviewer_name = "${{ github.event.requested_team.name }}"
 
-          curl -X POST -H "X-Api-Token: ${TOKEN}" "$FULL_URL" -d "$data_string"
+            request = urllib.request.Request("${{ steps.endpoint-details.url }}", headers={"X-Api-Token": "${{ steps.endpoint-details.token }}"}, method="POST")
+
+            data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + requested_reviewer
+            urllib.request.urlopen(request, data=data_string)

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -2,8 +2,6 @@ name: review-requested
 on:
   pull_request:
     types: [review_requested]
-  workflow_dispatch:
-
   workflow_call:
     secrets:
       AWS_ACCESS_KEY_ID:

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -40,7 +40,7 @@ jobs:
             elif requested_team:
               reviewer_name = "${{ github.event.requested_team.name }}"
 
-            repo = "${{ github.repository }}".split("/")[0]
+            repo = "${{ github.repository }}".split("/")[-1]
 
             data = {
               "pr_url": "${{ github.event.pull_request.html_url }}",

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -45,4 +45,4 @@ jobs:
             request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}", headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
 
             data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + requested_reviewer
-            urllib.request.urlopen(request, data=data_string)
+            urllib.request.urlopen(request, data=data_string.encode("utf-8"))

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -46,5 +46,5 @@ jobs:
 
             request = urllib.request.Request("${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo, headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"}, method="POST")
 
-            data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + requested_reviewer
+            data_string = "--pr_title '${{ github.event.pull_request.title }}' --pr_url ${{ github.event.pull_request.html_url }} --requestor ${{ github.event.sender.login }} --reviewer " + reviewer_name
             urllib.request.urlopen(request, data=data_string.encode("utf-8"))

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           script: |
             import json
-            import os
             import urllib.request
 
             requested_reviewer = "${{ github.event.requested_reviewer }}"
@@ -43,16 +42,21 @@ jobs:
 
             repo = "${{ github.repository }}".split("/")[0]
 
-            request = urllib.request.Request(
-              "${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo,
-              headers={"X-Api-Token": "${{ steps.endpoint-details.outputs.token }}"},
-              method="POST"
-            )
-
             data = {
               "pr_url": "${{ github.event.pull_request.html_url }}",
               "requestor": "${{ github.event.sender.login }}",
               "reviewer": reviewer_name
             }
             request_data = json.dumps(data).encode("utf-8")
-            urllib.request.urlopen(request, data=request_data)
+
+            request = urllib.request.Request(
+              "${{ steps.endpoint-details.outputs.url }}notify?event_type=review_requested&repo=" + repo,
+              headers={
+                "X-Api-Token": "${{ steps.endpoint-details.outputs.token }}",
+                "Content-Type"; "application/json"
+              },
+              method="POST",
+              data=request_data
+            )
+
+            urllib.request.urlopen(request)

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -28,7 +28,8 @@ jobs:
 
       - uses: actions/setup-python@v2
 
-      - name: jannekem/run-python-script-action@v1
+      - name: Call to send notification
+        uses: jannekem/run-python-script-action@v1
         with:
           script: |
             import urllib.request


### PR DESCRIPTION
Use Python rather than bash to pass the slack notification data to the API, in order to work around some of the messier parts of dealing with bash and various quote-like characters.

As the rather colorful PR title demonstrates, this method allows most of the special chars we've been struggling with to play through unimpeded, like so:
<img width="670" alt="CleanShot 2022-06-30 at 08 18 56@2x" src="https://user-images.githubusercontent.com/19318157/176687295-0fd590f8-3f71-457a-a9ae-94d047ba015b.png">
