### PR TITLE
Check Outdated PR Branch

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -126,7 +126,7 @@ jobs:
 
   deploy-review:
     name: Deploy Review Environment
-    needs: [changes, static-analysis, test, db-branch-check]
+    needs: [changes, static-analysis, test, db-branch-check, check-merge-base]
     if: ${{ failure() != true && cancelled() != true && (needs.changes.outputs.src == 'true' || needs.changes.outputs.stack-files == 'true') }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a PR check to verify if a branch is behind `main` and fail early.

Sample failure [here](https://github.com/unitasglobal/nis-data/runs/7394778301?check_suite_focus=true#step:2:301)

Sample success (checking a branch that's up-to-date with `main`) [here](https://github.com/unitasglobal/nis-data/runs/7394844908?check_suite_focus=true)