### PR TITLE
Better test result file management

### DIFF
--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -34,4 +34,3 @@ runs:
       uses: MishaKav/pytest-coverage-comment@v1.1.31
       with:
         pytest-xml-coverage-path: ./coverage.xml
-        junitxml-title: Test Results

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       if: success() || failure()
       with:
         name: PyTest Results
-        path: junit.xml
+        path: junit*.xml
         reporter: java-junit
 
     - name: Upload to CodeCov
@@ -33,5 +33,5 @@ runs:
     - name: PyTest Results Comment
       uses: MishaKav/pytest-coverage-comment@v1.1.31
       with:
-        junitxml-path: ./junit.xml
+        pytest-xml-coverage-path: ./coverage.xml
         junitxml-title: Test Results


### PR DESCRIPTION
Allow for multiple JUnit result files and move PyTest Results Comment to use the coverage XML since that is combined