### PR TITLE
Bb.version check fix

### DIFF
--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -36,6 +36,10 @@ runs:
       shell: bash
       run: ./run test self-check
 
+    - name: ensure main is accessible
+      shell: bash
+      run: git branch main >/dev/null 2>&1 || true
+
     - name: Run Version Check
       if: ${{ inputs.version_check == 'true' }}
       shell: bash

--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - name: ensure main is accessible
       shell: bash
-      run: git branch main >/dev/null 2>&1 || true
+      run: git branch main origin/main >/dev/null 2>&1 || true
 
     - name: Run Version Check
       if: ${{ inputs.version_check == 'true' }}


### PR DESCRIPTION
This should fix the "invalid object name 'main'" errors.
It appears that, while the main branch is being seen in fetch,
it is not (always?) linked as a local branch tracking origin/main.
This extra command should make sure that main is present
to pull file content from.