### PR TITLE
Use new set output method ahead of deprecation

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -44,7 +44,7 @@ jobs:
       - id: project_src_name
         run: |
           export PROJECT_SRC=$(basename "$GITHUB_REPOSITORY" | sed 's/-/_/g')
-          echo "::set-output name=project_src::$PROJECT_SRC"
+          echo "project_src=$PROJECT_SRC" >> $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@v2
         id: filter

--- a/.github/workflows/review-requested.yml
+++ b/.github/workflows/review-requested.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           URL=$(aws ssm get-parameter --name ' /nio/development/slack_notifications/url' --with-decryption | jq -r '.Parameter.Value')
           TOKEN=$(aws ssm get-parameter --name ' /nio/development/slack_notifications/token' --with-decryption | jq -r '.Parameter.Value')
-          echo "::set-output name=url::$URL"
-          echo "::set-output name=token::$TOKEN"
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-python@v3
 

--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         fetch_depth=1
         if [[ ${{ inputs.version_check }} == 'true' ]]; then fetch_depth=0; fi
-        echo "::set-output name=fetch_depth::$fetch_depth"
+        echo "fetch_depth=$fetch_depth" >> $GITHUB_OUTPUT
 
     - uses: unitasglobal/nio-shared-actions/python-setup@main
       with:


### PR DESCRIPTION
Blog post: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updated docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter