### PR TITLE
Create a buildx builder to be used optionally for reqs image

### DIFF
--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -26,8 +26,14 @@ jobs:
         with:
           python_version: ${{ inputs.python_version }}
 
+      - uses: docker/setup-buildx-action
+        id: buildx-setup
+        with:
+          platforms: linux/amd64,linux/arm64
+          use: false
+
       - name: Build and Push Images
-        run: ./run docker build-and-push-requirements
+        run: ./run docker build-and-push-requirements --multibuilder ${{ steps.buildx-setup.outputs.name }}
 
       - name: Post Workflow Failed to Slack
         if: ${{ failure() }}

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python_version: ${{ inputs.python_version }}
 
-      - uses: docker/setup-buildx-action
+      - uses: docker/setup-buildx-action@v2
         id: buildx-setup
         with:
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Set up a buildx builder for the requirements image, so that repos using a latest
version of the UT scripting will benefit from a multi-arch build of the image.
Note that repos using _older_ versions of UT will let these arguments pass
untouched so there is no backwards-incompatibility to worry about (thanks,
star-kwargs).

Pairs with [this UT PR](https://github.com/unitasglobal/unitas_tools/pull/327)
