### PR TITLE
larger runner image builds

### DIFF
--- a/.github/workflows/deploy-library.yml
+++ b/.github/workflows/deploy-library.yml
@@ -19,7 +19,7 @@ env:
   DOCKER_BUILDKIT: 1
 jobs:
   deploy-library:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: unitasglobal/nio-shared-actions/deploy-library@main
         with:

--- a/.github/workflows/deploy-library.yml
+++ b/.github/workflows/deploy-library.yml
@@ -19,7 +19,7 @@ env:
   DOCKER_BUILDKIT: 1
 jobs:
   deploy-library:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: unitasglobal/nio-shared-actions/deploy-library@main
         with:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -135,10 +135,28 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           python_version: ${{ inputs.python_version }}
 
+  build-lambda-image:
+    name: Build Lambda ECR Image
+    needs: [changes, static-analysis, check-merge-base]
+    if: ${{ failure() != true && cancelled() != true && (needs.changes.outputs.src == 'true' || needs.changes.outputs.stack-files == 'true') }}
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: unitasglobal/nio-shared-actions/python-setup@main
+
+      - uses: docker/setup-buildx-action@v2
+        id: buildx-setup
+        with:
+          platforms: linux/amd64,linux/arm64
+          use: false
+
+      - name: Build and deploy images
+        shell: bash
+        run: ./run docs build-docs && ./run cdk --modifier ${{ inputs.modifier }} prepare-ecr-image --multibuilder ${{ steps.buildx-setup.outputs.name }}
+
   deploy-review:
     name: Deploy Review Environment
     concurrency: deploy-review-${{ github.ref_name }}
-    needs: [changes, static-analysis, test, db-branch-check, check-merge-base]
+    needs: [changes, static-analysis, test, db-branch-check, check-merge-base, build-lambda-image]
     if: ${{ failure() != true && cancelled() != true && (needs.changes.outputs.src == 'true' || needs.changes.outputs.stack-files == 'true') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Build and deploy images
         shell: bash
-        run: ./run docs build-docs && ./run cdk --modifier ${{ inputs.modifier }} prepare-ecr-image --multibuilder ${{ steps.buildx-setup.outputs.name }}
+        run: ./run docs build-docs && ./run cdk --review ${{ github.event.number }} prepare-ecr-image --multibuilder ${{ steps.buildx-setup.outputs.name }}
 
   deploy-review:
     name: Deploy Review Environment

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -142,6 +142,8 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: unitasglobal/nio-shared-actions/python-setup@main
+        with:
+          python_version: ${{ inputs.python_version }}
 
       - uses: docker/setup-buildx-action@v2
         id: buildx-setup

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-requirements:
     name: Build Requirements ECR Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: unitasglobal/nio-shared-actions/python-setup@main
         with:


### PR DESCRIPTION
* Use a larger GH runner for the `update-requirements` job
* Prebuild the ECR image (on a larger runner) for PR deploys while tests are running so that the deploy job can run quickly with the image already in-place

Sample PR build run [here](https://github.com/unitasglobal/nio-intelligence-api/actions/runs/3997618619) -- test failed (will be addressed separately), but the image build succeeds as expected