### PR TITLE
Action Updates

### DIFF
--- a/python-setup/action.yml
+++ b/python-setup/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: actions/setup-node@v3
       if: ${{ inputs.install_node == 'true' }}
       with:
-        node-version: "14"
+        node-version: "18"
 
     - name: Install zip
       if: runner.os == 'Linux'

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -37,6 +37,6 @@ runs:
         files: ./coverage.xml
 
     - name: PyTest Results Comment
-      uses: MishaKav/pytest-coverage-comment@v1.1.37
+      uses: MishaKav/pytest-coverage-comment@v1.1.47
       with:
         pytest-xml-coverage-path: ./coverage.xml


### PR DESCRIPTION
- Update node-version to one that isn't about to reach EOL
- Update pytest-coverage-comment to latest since they don't support major version pinning
