### PR TITLE
Support GH API token for Packer to avoid rate-limiting

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -17,10 +17,13 @@ on:
         required: true
       PROD_AWS_SECRET_ACCESS_KEY:
         required: true
+      PACKER_GH_TOKEN:
+        required: false
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
+  PACKER_GITHUB_API_TOKEN: ${{ secrets.PACKER_GH_TOKEN }}
   DOCKER_BUILDKIT: 1
 jobs:
   deploy-production:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -29,10 +29,13 @@ on:
         required: true
       CODECOV_TOKEN:
         required: true
+      PACKER_GH_TOKEN:
+        required: false
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
+  PACKER_GITHUB_API_TOKEN: ${{ secrets.PACKER_GH_TOKEN }}
   DOCKER_BUILDKIT: 1
 jobs:
   changes:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -12,10 +12,13 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
+      PACKER_GH_TOKEN:
+        required: false
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: us-east-1
+  PACKER_GITHUB_API_TOKEN: ${{ secrets.PACKER_GH_TOKEN }}
   DOCKER_BUILDKIT: 1
 jobs:
   deploy-staging:


### PR DESCRIPTION
Tested this in a dependent repo both with and without the `PACKER_GH_TOKEN` secret provided and both worked as expected, so this should be a non-breaking change for repos where we do not set/provide our PAT, but will allow Packer to use the token when provided to avoid rate-limiting.