### PR TITLE
CCM-6390:  Run Tests even if selfcheck is skipped

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -65,8 +65,6 @@ jobs:
               - 'src/**'
               - '${{ steps.project_src_name.outputs.project_src }}/**'
               - 'yarn.lock'
-              - '*.lock'
-              - '*.toml'
             tests:
               - 'tests/**'
             stack-files:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -133,7 +133,7 @@ jobs:
   test:
     name: Run Tests
     needs: [changes, static-analysis, check-merge-base]
-    if: ${{ needs.changes.outputs.has_tests == 'true' && (needs.changes.outputs.tests == 'true' || needs.changes.outputs.src == 'true' || needs.changes.outputs.ci-files == 'true') }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.has_tests == 'true' && (needs.changes.outputs.tests == 'true' || needs.changes.outputs.src == 'true' || needs.changes.outputs.ci-files == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: unitasglobal/nio-shared-actions/run-tests@main


### PR DESCRIPTION
https://packetfabric.atlassian.net/browse/CCM-6390

I found that the tests were being skipped if self check is skipped.
This isn't intended, as we want the tests to run if there is a dependency update where self check isn't needed.  Self check only runs when a python file is updated.

This was very difficult to track down, but it turns out was / is related to this issue:
https://github.com/actions/runner/issues/491
which turns out is actually a hidden feature:
https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
Turns out that if a job has one of its dependent jobs that is marked as a needs skipped, it will also be skipped as it has a default ``if success()`` applied to it.  which reads like this: "Returns true when all previous steps have succeeded.".  If a previous job was skipped, it didn't succeed, it was just skipped.  The solution is we have to add some sort of status check function to our "if" in order for it to evaluate.

The suggestion is to check for: ``!failure() && !canceled()``.  This is similar to what is done on other jobs, though I didn't know why at the time.

I also removed the checks for *.lock and *.toml files as it turned out those were not needed.  I originally thought those evaluations were failing to find the poetry.lock file.